### PR TITLE
Fix 404 for Documentation

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -2,7 +2,7 @@
 title = "Documentation"
 weight = 1
 sort_by = "weight"
-redirect_to = "Installation"
+redirect_to = "docs/installation"
 +++
 
 Here you find all necessary information about what Varlociraptor offers and how to use it.


### PR DESCRIPTION
It seems like clicking on **Documentation** at the sidebar leads to a `404` since `https://varlociraptor.github.io/Installation/` doesn't exist. I am not sure if thats a problem with the redirect_to from the [zola book theme](https://github.com/getzola/book) not working properly with subsections or just bad usage (documentation on that doesn't address that case). Anyway i hope this should fix the problem.